### PR TITLE
Use the right version of Lua in CI.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -5,4 +5,15 @@ set -eu
 shellcheck run.sh
 shellcheck suites/*/run.sh
 shellcheck .buildbot.sh
-sh run.sh /usr/bin/lua5.3
+
+# Run the tests with the same version of upstream Lua that yklua is based upon,
+# just as a quick sanity check.
+v=5.4.6
+tb=lua-${v}.tar.gz
+wget "https://lua.org/ftp/${tb}"
+tar zxf ${tb}
+cd lua-${v}
+make -j "$(nproc)"
+cd ..
+
+sh run.sh "${PWD}/lua-${v}/src/lua"

--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -4,7 +4,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
   rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
-  apt-get -y install lua5.3 shellcheck
+  apt-get -y install shellcheck build-essential wget
 ARG CI_UID
 RUN useradd -m -u ${CI_UID} ci && chown ${CI_UID}:${CI_UID} .
 ARG CI_RUNNER


### PR DESCRIPTION
(We don't use the system Lua-5.4, because we know the Debian one currently has bugs and it's better to use the exact version yklua is based upon anyway).